### PR TITLE
Config/Logback Symlink Patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN if [ "$SYMLINK_CONF" = "true" ] || [ "$SYMLINK_LOGBACK" = "true" ] || [ "$SY
     fi
     
 # Copy gitignore into the working
-COPY seed-contents/ /usr/local/bin/seed-contents/
-COPY --chmod=0755 entrypoint-shim.sh /usr/local/bin/
+COPY --chown=${IGNITION_UID}:${IGNITION_GID} seed-contents/ /usr/local/bin/seed-contents/
+COPY --chmod=0755 --chown=${IGNITION_UID}:${IGNITION_GID} entrypoint-shim.sh /usr/local/bin/
 
 # Set the default user and group for the image
 USER ${IGNITION_UID}:${IGNITION_GID}

--- a/entrypoint-shim.sh
+++ b/entrypoint-shim.sh
@@ -31,11 +31,15 @@ mv ../seed-contents/.gitignore ${WORKING_DIRECTORY}/
 # Create the data folder for Ignition for any upcoming symlinks
 mkdir -p ${IGNITION_INSTALL_LOCATION}/data
 
-
-
 # Create the symlink for the conf folder if enabled
 if [ "$SYMLINK_CONF" = "true" ]; then \
     mv ../seed-contents/ignition.conf ${WORKING_DIRECTORY}/ignition.conf
+
+    # If the conf folder exists, remove it
+    if [ -e ${IGNITION_INSTALL_LOCATION}/data/conf ]; then
+        rm -rf ${IGNITION_INSTALL_LOCATION}/data/conf
+    fi
+
     ln -s ${WORKING_DIRECTORY}/ignition.conf /usr/local/bin/ignition/ignition.conf
 
     # Set the wrapper.java.additional.2=-Dignition.projects.scanFrequency = to PROJECT_SCAN_FREQUENCY in ignition.conf
@@ -45,6 +49,12 @@ fi
 # Create the symlink for the logback.xml file if enabled
 if [ "$SYMLINK_LOGBACK" = "true" ]; then \
     mv ../seed-contents/logback.xml ${WORKING_DIRECTORY}/logback.xml
+
+    # If the logback.xml file exists, remove it
+    if [ -e ${IGNITION_INSTALL_LOCATION}/data/logback.xml ]; then
+        rm -rf ${IGNITION_INSTALL_LOCATION}/data/logback.xml
+    fi
+
     ln -s ${WORKING_DIRECTORY}/logback.xml /usr/local/bin/ignition/logback.xml
 fi
 


### PR DESCRIPTION
In the entry point shim, there was not a check in place to remove the `conf` and `logback` files before they were symlinked in place. This was causing them to fail to create the link.